### PR TITLE
RainbowCars: Hook SetupRender and ResetAfterRender

### DIFF
--- a/src/effects/impl/RainbowCars.h
+++ b/src/effects/impl/RainbowCars.h
@@ -1,7 +1,8 @@
 // Copyright (c) 2019 Lordmau5
 #pragma once
 
-#include <map>
+#include <vector>
+#include <utility>
 
 #include "effects/abstract/TimedEffect.h"
 
@@ -13,11 +14,6 @@
 class RainbowCars : public TimedEffect
 {
 public:
-	static bool isEnabled;
-	static float hueShift;
-	static std::map<RpMaterial*, RwRGBA> RainbowCars::resetMaterials;
-
-public:
 	RainbowCars(int _duration, std::string _description);
 
 	void Enable() override;
@@ -25,9 +21,15 @@ public:
 
 	void HandleTick() override;
 
-	static void RenderVehicleEvent(CVehicle* vehicle);
+private:
+	static void SetupRenderEvent(CVehicle* vehicle);
+	static void ResetAfterRenderEvent(CVehicle* vehicle);
 	static void ModifyCarPaint(CVehicle* vehicle);
 
 	static RpMaterial* MaterialCallback(RpMaterial* material, void* color);
 	static RpAtomic* AtomicCallback(RpAtomic* atomic, void* color);
+
+private:
+	static float hueShift;
+	static std::vector< std::pair<RwRGBA*, RwRGBA> > resetMaterialColors;
 };


### PR DESCRIPTION
Now instead of keeping track of recolored materials globally (which was unsafe, because those materials could potentially be destroyed by then!), it sets them up and restores before/after every vehicle render, just like stock editable materials are.

This should resolve pretty much all issues with this effect, such as:
- Editable materials (lights mainly) not working after the effect has been disabled
- Miscolored damage parts

It's also more than likely that it fixes #11.